### PR TITLE
fix: do not coerce StringIO into str

### DIFF
--- a/pyinfra_testing/util.py
+++ b/pyinfra_testing/util.py
@@ -8,6 +8,7 @@ import types
 import typing
 from datetime import datetime, timezone
 from inspect import Parameter, getcallargs, getfullargspec, signature
+from io import StringIO
 from os import path
 from pathlib import Path
 from unittest.mock import patch
@@ -53,6 +54,8 @@ def parse_value(value):
             return datetime.fromisoformat(value[9:])
         if value.startswith("path:"):
             return Path(value[5:])
+        if value.startswith("io:"):
+            return StringIO(value[3:])
         return value
 
     if isinstance(value, list):
@@ -74,6 +77,7 @@ def _is_plain_instance(value, annotation):
         and typing.get_origin(annotation) is None
         and not issubclass(annotation, enum.Enum)
         and not dataclasses.is_dataclass(annotation)
+        and not isinstance(value, StringIO)
         and isinstance(value, annotation)
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyinfra-testing"
-version = "0.2.0"
+version = "0.2.1"
 description = "Generate Python unit tests from JSON and YAML files"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
A recent commit to pyinfra introduces `io:<string content>` as a way to pass StringIO objects to operations in test fixtures. pyinfra-testing did not support this yet. Now it does.